### PR TITLE
Use Ubuntu 14.04. and remove old PHP5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update
 RUN apt-get install -y \
     git make curl \
     nginx-light \
-    php5=5.6.7+dfsg-1 php5-fpm=5.6.7+dfsg-1 php5-common=5.6.7+dfsg-1 php5-cli=5.6.7+dfsg-1 \
-    php5-odbc=5.6.7+dfsg-1 php5-curl=5.6.7+dfsg-1 \
+    php5 php5-fpm php5-common php5-cli \
+    php5-odbc php5-curl \
     unixodbc
 
 # Add virtuoso odbc dependency for OntoWiki to me able to connecto to virtuoso

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:14.04
 
 MAINTAINER Natanael Arndt <arndt@informatik.uni-leipzig.de>
 


### PR DESCRIPTION
Remove the version of php, because it's not in Debians/Ubuntus repository anymore.

Use Ubuntu 14.04. instead of Debian as image solves a bug with Nginx+PHP5-fpm, which causes an 502 Bad Gateway error when trying to access http://localhost/ (see commit for details)
